### PR TITLE
allow elements missing closing tags (#38)

### DIFF
--- a/markdownPreview/src/components/App.tsx
+++ b/markdownPreview/src/components/App.tsx
@@ -87,11 +87,16 @@ const App = (props: AppProps) => {
     const { jsx } = props;
     const { isDarkMode, enable, disable } = useDarkMode();
     const [_, setBaseHref] = useSessionStorage("baseHref", "");
-    const [menuProps, _setMenuProps] = useSessionStorage("menu", "");
+    const [menuProps, setMenuProps] = useSessionStorage("menu", JSON.stringify({}));
     useEffect(() => {
         document.body.classList.contains("vscode-dark") ? enable() : disable();
         setBaseHref(props.baseHref);
     }, []);
+    useEffect(() => {
+       if (!jsx.includes("<taipy_menu")) {
+            setMenuProps(JSON.stringify({}));
+       }
+    }, [jsx]);
     const theme = isDarkMode ? "dark" : "light";
     const themeClass = `taipy-${theme}`;
     const MuiTheme = userTheme[theme];
@@ -124,7 +129,8 @@ const App = (props: AppProps) => {
                                     allowUnknownElements={false}
                                     renderError={renderError}
                                     blacklistedAttrs={[]}
-                                    blacklistedTags={[]}
+                                    blacklistedTags={["svg"]}
+                                    autoCloseVoidElements={true}
                                 />
                             </ErrorBoundary>
                         </Box>

--- a/markdownPreview/src/components/Taipy/MenuCtl.tsx
+++ b/markdownPreview/src/components/Taipy/MenuCtl.tsx
@@ -16,7 +16,7 @@ import { useEffect } from "react";
 import { useSessionStorage } from "usehooks-ts";
 
 const MenuCtl = (props: MenuProps) => {
-    const [_, setMenuProps] = useSessionStorage("menu", "");
+    const [_, setMenuProps] = useSessionStorage("menu", JSON.stringify({}));
     useEffect(() => {
         setMenuProps(JSON.stringify(props));
     }, []);

--- a/markdownPreview/src/index.tsx
+++ b/markdownPreview/src/index.tsx
@@ -15,14 +15,19 @@ import { createRoot } from "react-dom/client";
 import App from "./components/App";
 
 function init() {
-    const rootDiv = document.createElement("div", {});
-    rootDiv.setAttribute("id", "root");
-    const bodyInnerHTML = document.body.innerHTML;
-    const baseHref = (document.querySelector('base') || {}).href || "";
-    document.body.innerHTML = "";
-    document.body.appendChild(rootDiv);
+    const mdbd = document.getElementsByClassName("markdown-body");
+    const markdownBodyHTML = mdbd[mdbd.length - 1].outerHTML;
+    mdbd[mdbd.length - 1].remove();
+    const baseHref = (document.querySelector("base") || {}).href || "";
+    let rootDiv = document.querySelector("#root");
+    if (!rootDiv) {
+        rootDiv = document.createElement("div", {});
+        rootDiv.setAttribute("id", "root");
+        document.body.appendChild(rootDiv);
+    }
+    rootDiv.innerHTML = "";
     const root = createRoot(rootDiv);
-    root.render(<App jsx={bodyInnerHTML} baseHref={baseHref} />);
+    root.render(<App jsx={markdownBodyHTML} baseHref={baseHref} />);
 }
 
 window.addEventListener("vscode.markdown.updateContent", init);


### PR DESCRIPTION
Fix issue #38 and:
- Menu still persisted even if md has been removed (#41)
- better md parsing (only parse markdown content rather than the whole html body) (#40)